### PR TITLE
Make pull-secrets a common option in JX

### DIFF
--- a/pkg/jx/cmd/common.go
+++ b/pkg/jx/cmd/common.go
@@ -119,9 +119,7 @@ func (options *CommonOptions) addCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&options.NoBrew, "no-brew", "", false, "Disables the use of brew on MacOS to install or upgrade command line dependencies")
 	cmd.Flags().BoolVarP(&options.InstallDependencies, "install-dependencies", "", false, "Should any required dependencies be installed automatically")
 	cmd.Flags().BoolVarP(&options.SkipAuthSecretsMerge, "skip-auth-secrets-merge", "", false, "Skips merging a local git auth yaml file with any pipeline secrets that are found")
-
-	// todo not sure we need this, but would be useful if other things need to use it. But then how does it get prompted at env create time...
-	// cmd.Flags().StringVarP(&options.PullSecrets, "pull-secrets", "", "", "The pull secrets the service account created should have (useful when deploying to your own private registry)")
+	cmd.Flags().StringVarP(&options.PullSecrets, "pull-secrets", "", "", "The pull secrets the service account created should have (useful when deploying to your own private registry)")
 
 	options.Cmd = cmd
 }
@@ -285,6 +283,11 @@ func (o *CommonOptions) TeamAndEnvironmentNames() (string, string, error) {
 		return "", "", err
 	}
 	return kube.GetDevNamespace(kubeClient, currentNs)
+}
+
+func (o *CommonOptions) ParseImagePullSecrets() []string {
+	pullSecrets := strings.Fields(o.PullSecrets)
+	return pullSecrets
 }
 
 func (o *ServerFlags) addGitServerFlags(cmd *cobra.Command) {

--- a/pkg/kube/env.go
+++ b/pkg/kube/env.go
@@ -882,32 +882,3 @@ func NewPreviewEnvironment(name string) *v1.Environment {
 		},
 	}
 }
-
-// PickPullSecrets prompts users to provide pull secret names for created service accounts to use
-func PickPullSecrets(in terminal.FileReader, out terminal.FileWriter, errOut io.Writer) (string, error) {
-	surveyOpts := survey.WithStdio(in, out, errOut)
-	secrets := ""
-
-	q := &survey.Input{
-		Message: "Pull secrets?",
-		Default: "",
-		Help:    "The pull secrets required for applications in the created environment to function",
-	}
-	err := survey.AskOne(q, &secrets, nil, surveyOpts)
-
-	// Ideally we provide options: image pull secrets (so of type Docker secret) that sit in the installde into namespace
-	// Service accounts will then use this secret. May need to copy each secret into the environment namespace for that to work.
-	// For now, just accept user text input
-
-	if err != nil {
-		log.Error("An error occurred when prompting for the list of secrets to use")
-		return "", err
-	}
-	return secrets, nil
-}
-
-// PatchServiceAccount patches a given service account with a pull secret, for an environment
-func PatchServiceAccount(kubeClient kubernetes.Interface, jxClient versioned.Interface, ns, pullSecret string) error {
-	log.Infof("todo impl, pull secret listing is %s, namespace is %s", pullSecret, ns)
-	return nil
-}

--- a/pkg/kube/service_accounts.go
+++ b/pkg/kube/service_accounts.go
@@ -16,16 +16,20 @@ type ImagePullSecret struct {
 	Name string `json:"name"`
 }
 
-// PatchImagePullSecret patches the specified ImagePullSecret to the given service account
-func PatchImagePullSecret(kubeClient kubernetes.Interface, ns string, sa string, imagePullSecret string) error {
+// PatchImagePullSecrets patches the specified ImagePullSecrets to the given service account
+func PatchImagePullSecrets(kubeClient kubernetes.Interface, ns string, sa string, imagePullSecrets []string) error {
 	log.Infof("Namespace: %s\n", ns)
 	log.Infof("Service Account: %s\n", sa)
-	log.Infof("Secret: %s\n", imagePullSecret)
+	log.Infof("Secret: %s\n", imagePullSecrets)
 
 	// '{"imagePullSecrets": [{"name": "<secret>"}]}'
-	ips := []ImagePullSecret{{
-		Name: imagePullSecret,
-	}}
+	var ips []ImagePullSecret
+	for _, secret := range imagePullSecrets {
+		jsonSecret := ImagePullSecret{
+			Name: secret,
+		}
+		ips = append(ips, jsonSecret)
+	}
 	payload := JsonPatch{
 		ImagePullSecret: &ips,
 	}


### PR DESCRIPTION
* Makes pull-secrets a common option, accessible to any command that uses the CommonOptions
* Updates PatchImagePullSecrets to iterate over a list of secrets, rather than iteratively calling the function
* Uses string.Fields to parse the secrets
* Removes the interactive mode to simplify things. 